### PR TITLE
Fix typo in plugin naming docs

### DIFF
--- a/bootstrap-core/src/main/java/org/ligoj/bootstrap/core/plugin/FeaturePlugin.java
+++ b/bootstrap-core/src/main/java/org/ligoj/bootstrap/core/plugin/FeaturePlugin.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * A plug-in. The plug-in behavior is massively based on naming convention. The key of the plug-in must be unique and
- * following the bellow rules :
+ * following the below rules :
  * <ul>
  * <li>Must follows this pattern <code>[a-z\d]+(:[a-z\d]+)*</code></li>
  * <li>Must be unique</li>


### PR DESCRIPTION
## Summary
- fix "bellow" -> "below" in FeaturePlugin javadoc

## Testing
- `grep -n "below" -n bootstrap-core/src/main/java/org/ligoj/bootstrap/core/plugin/FeaturePlugin.java`